### PR TITLE
nodejs 4.2.2 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "node.git"]
 	path = node.git
-	url = https://github.com/joyent/node.git
+	url = https://github.com/nodejs/node.git

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nodejs (4.2.2-1) UNRELEASED; urgency=low
+
+  * 4.2.2 release from upstream
+
+ -- Tz-Huan Huang <tzhuan@gmail.com>  Mon, 16 Nov 2015 00:22:32 +0800
+
 nodejs (0.12.7-1) UNRELEASED; urgency=low
 
   * openssl: upgrade to 1.0.1p

--- a/debian/rules
+++ b/debian/rules
@@ -6,6 +6,6 @@ override_dh_auto_install:
 	$(MAKE) DESTDIR=$$(pwd)/debian/nodejs prefix=/usr install
 
 override_dh_auto_configure:
-	./configure --prefix=/usr --shared-openssl --openssl-libpath=/usr/lib/ssl --shared-zlib
+	./configure --prefix=/usr --shared-zlib
 
 override_dh_auto_test:


### PR DESCRIPTION
With the patch I can build nodejs 4.2.2 on debian jessie successfully. Please consider merging it, thanks.
